### PR TITLE
Fix separator margins of menus created with gtk_menu_button_set_menu_model()

### DIFF
--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -3686,6 +3686,11 @@ popover.menu,
     background-image: none;
 }
 
+popover.menu separator:first-child,
+.popover.menu separator:first-child {
+    margin: 4px 0;
+}
+
 .popover > .location-bar,
 .popover.osd > .toolbar,
 .popover.osd > .inline-toolbar,


### PR DESCRIPTION
The spacing between section separators in popover menus created with [gtk_menu_button_set_menu_model()](https://developer.gnome.org/gtk3/stable/GtkMenuButton.html#gtk-menu-button-set-menu-model) does not have the same spacing as other menu separators. This pull request attempts to fix that.